### PR TITLE
Handle new node types and improve performance.

### DIFF
--- a/accs_for_couchdb2neo4j.py
+++ b/accs_for_couchdb2neo4j.py
@@ -117,6 +117,7 @@ definitive_edges2 = {
 
 # Remap the study names using these values
 study_name_dict = {
+    'Healthy Human Subjects':'HHS',
     'Human microbiome project 16S production phase I.':'16S-PP1',
     'Human microbiome project 16S production phase II.':'16S-PP2',
     'Skin Microbiome in Disease States: Atopic Dermatitis and Immunodeficiency.':'16S-SM-ADI',

--- a/accs_for_couchdb2neo4j.py
+++ b/accs_for_couchdb2neo4j.py
@@ -18,7 +18,7 @@ def mod_quotes(val):
             val = float(val) # float just in case
     return val
 
-# This dictionary simply reformats aspects like capitalization for Neo4j. 
+# Mapping from OSDF node type to Neo4J node type (Case, File, Tags) or MIMARKS, Mixs
 nodes = {
     'project': 'Case',
     'study': 'Case',
@@ -54,8 +54,21 @@ nodes = {
     'abundance_matrix': 'File',
     'tags': 'Tags',
     'mimarks': 'MIMARKS',
-    'mixs': 'Mixs'
+    'mixs': 'Mixs',
+    'reference_genome_project_catalog_entry': 'File',
+    'host_epigenetics_raw_seq_set': 'File',
+    'serology': 'File',
+    'metagenomic_project_catalog_entry': 'File',
+    'alignment': 'File',
+    'proteome_nonpride': 'File',
+    'host_variant_call': 'File'
 }
+
+# OSDF node types that map to Neo4J File nodes
+file_nodes = {}
+for n in nodes:
+    if nodes[n] == 'File':
+        file_nodes[n] = True
 
 # These are all the different edge types present in the schema. 
 # Note that 'subset_of' will be removed after loading in order to 
@@ -337,29 +350,6 @@ fma_free_body_site_dict = {
     'vaginal_introitus': 'orifice of vagina',
     'volar_forearm': 'forearm',
     'wall_of_vagina': 'wall of vagina',
-}
-
-# differentiate the file nodes from all others
-files_only = {
-    'wgs_raw_seq_set',
-    'wgs_raw_seq_set_private',
-    'host_wgs_raw_seq_set',
-    'microb_transcriptomics_raw_seq_set',
-    'host_transcriptomics_raw_seq_set',
-    'wgs_assembled_seq_set',
-    'viral_seq_set',
-    'annotation',
-    'clustered_seq_set',
-    '16s_dna_prep',
-    '16s_raw_seq_set',
-    '16s_trimmed_seq_set',
-    'microb_assay_prep',
-    'host_assay_prep',
-    'proteome',
-    'metabolome',
-    'lipidome',
-    'cytokine',
-    'abundance_matrix'
 }
 
 # be explicit about which metadata makes it through the _attr nodes so as not

--- a/couchdb2neo4j_with_tags.py
+++ b/couchdb2neo4j_with_tags.py
@@ -471,7 +471,10 @@ def _isolate_relevant_prep_edge(doc):
     # certain nodes are expected to map to multiple upstream SRS ids:
     #    wgs_assembled_seq_set/wgs_coassembly (for coassembled iHMP samples)
     #    16s_trimmed_seq_set/trimmed_16s (for multiplexed JCVI samples)
-    if doc['main']['subtype'] != 'wgs_coassembly' and doc['main']['subtype'] != 'trimmed_16s':
+    #    wgs_assembled_seq_set/wgs_assembly for body-site-specific assemblies
+    if ((doc['main']['subtype'] != 'wgs_coassembly' and doc['main']['subtype'] != 'trimmed_16s') 
+        and
+        (doc['main']['subtype'] != 'wgs_assembly' and doc['main']['name'] != "Body-site specific assemblies")):
         pp = pprint.PrettyPrinter(indent=4, stream=sys.stdout)
         sys.stdout.write("SRS# cannot be found upstream for node of type/subtype = {0}/{1}\n".format(doc['main']['node_type'], doc['main']['subtype']))
         pp.pprint(doc)

--- a/couchdb2neo4j_with_tags.py
+++ b/couchdb2neo4j_with_tags.py
@@ -688,21 +688,17 @@ def _build_all_indexes(node,cy):
     etime = time.time()
     _print_error("built {0} {1} indexes in {2:.2f} second(s)".format(n_indexes, node, etime-stime))
 
-# Escape quotes to keep Cypher happy
-def _mod_quotes(val):
+# Apply body site rewrites from fma_free_body_site_dict
+def _mod_body_site(val):
 
     if isinstance(val, list):
         for x in val:
             if x in fma_free_body_site_dict:
                 x = fma_free_body_site_dict[x]
-            x = x.replace("'","\\'")
-            x = x.replace('"','\\"')
 
     else:
         if val in fma_free_body_site_dict:
             val = fma_free_body_site_dict[val]
-        val = val.replace("'","\\'")
-        val = val.replace('"','\\"')
 
     return val
 
@@ -758,7 +754,7 @@ def _traverse_document(doc,focal_node,index):
                     endpoint = val[j].split(':')[0]
                     props.append({'key': '{0}{1}'.format(key_prefix,endpoint), 'value': '{0}'.format(val[j]), 'quoted': True })
         else:
-            val = _mod_quotes(val)
+            val = _mod_body_site(val)
             key = key.encode('utf-8')
             val = val.encode('utf-8')
             props.append({'key': '{0}{1}'.format(key_prefix,key), 'value': '{0}'.format(val), 'quoted': True })

--- a/couchdb2neo4j_with_tags.py
+++ b/couchdb2neo4j_with_tags.py
@@ -70,7 +70,6 @@ def _all_docs_by_page(db_url, cache_dir=None, page_size=10):
                     page = { "status_code": 200, "content": page_content, "source": "cache" }
 
         if page is None:
-            print("making HTTP request for page %d" % pagenum)
             response = requests.get(db_url + "/_all_docs", params=params)
             page = { "status_code": response.status_code, "content": response.content, "source": "DB" }
             # write page to cache

--- a/couchdb2neo4j_with_tags.py
+++ b/couchdb2neo4j_with_tags.py
@@ -1019,7 +1019,8 @@ def _do_cypher_insert(cy, insert_cypher, obj_list, obj_type):
             tx.run(ins_cypher, { 'objects': o_slice })
             tx.commit()
             b_etime = time.time()
-            _print_error("commit() done, insert took {0:.02f} second(s)".format(b_etime - b_stime))
+# uncomment for batch-level timing info:
+#            _print_error("commit() done, insert took {0:.02f} second(s)".format(b_etime - b_stime))
 
     etime = time.time()
     _print_error("inserted {0} {1} in {2:.2f} second(s)".format(len(obj_list), obj_type, etime-stime))


### PR DESCRIPTION
Handle new (as of fall 2018) OSDF node types and improve performance by using UNWIND to batch inserts/updates that are able to share the same Cypher query. Also adds several new command-line parameters to support caching and providing authentication to the source CouchDB/OSDF store. The main caveat as that the use of UNWIND requires a recent target Neo4J instance, preferably 3.4.5 or newer.